### PR TITLE
Fixing contextPath and making it not look lame ;)

### DIFF
--- a/duo_twofactor/pom.xml
+++ b/duo_twofactor/pom.xml
@@ -28,13 +28,13 @@
         <dependency>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
-          <version>2.4</version>
+          <version>2.5</version>
           <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
-            <version>6.0</version>
+            <version>7.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.atlassian.confluence.plugin</groupId>
             <artifactId>func-test</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>net.sourceforge.nekohtml</groupId>
             <artifactId>nekohtml</artifactId>
-            <version>1.9.12</version>
+            <version>1.9.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -92,9 +92,9 @@
     </build>
 
     <properties>
-        <confluence.version>5.1.3</confluence.version>
-        <confluence.data.version>5.1.3</confluence.data.version>
-        <amps.version>5.0.4</amps.version>
+        <confluence.version>5.7.1</confluence.version>
+        <confluence.data.version>5.7.1</confluence.data.version>
+        <amps.version>5.0.13</amps.version>
         <plugin.testrunner.version>1.1.1</plugin.testrunner.version>
     </properties>
 

--- a/duo_twofactor/src/main/java/com/duosecurity/confluence/plugins/TwoFactorLoginServlet.java
+++ b/duo_twofactor/src/main/java/com/duosecurity/confluence/plugins/TwoFactorLoginServlet.java
@@ -47,7 +47,8 @@ public class TwoFactorLoginServlet extends HttpServlet
         // Encode the template arguments in case we're < 5.1.2
         context.put("sigRequest", StringEscapeUtils.escapeJavaScript(request.getParameter(DUO_REQUEST_KEY)));
         context.put("duoHost", StringEscapeUtils.escapeJavaScript(request.getParameter(DUO_HOST_KEY)));
-        context.put("actionUrl", StringEscapeUtils.escapeJavaScript(UriBuilder.fromUri(actionUrl).queryParam(DUO_ORIGINAL_URL_KEY, actionArg).build().toString()));
+        context.put("actionUrl", StringEscapeUtils.escapeJavaScript(request.getContextPath() + UriBuilder.fromUri(actionUrl).queryParam(DUO_ORIGINAL_URL_KEY, request.getContextPath() + actionArg).build().toString()));
+	context.put("contextPath", request.getContextPath());
         renderer.render("duologin.vm", context, response.getWriter());
     }
 

--- a/duo_twofactor/src/main/resources/duologin.vm
+++ b/duo_twofactor/src/main/resources/duologin.vm
@@ -3,13 +3,13 @@
   <head>
     <title>Duo Authentication</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="decorator" content="atl.general"/>
   </head>
 
   <body style="text-align: center;">
-    <h1>Duo Authentication</h1>
 
      <div>
-       <script src="/download/resources/com.duosecurity.confluence.plugins.duo-twofactor:resources/Duo-Web-v1.bundled.js"></script>
+       <script src="$contextPath/download/resources/com.duosecurity.confluence.plugins.duo-twofactor:resources/Duo-Web-v1.bundled.js"></script>
        <script>
          Duo.init({
            'host': "$duoHost",
@@ -17,7 +17,7 @@
            'post_action': "$actionUrl"
          });
        </script>
-       <iframe height="500" width="620" id="duo_iframe" frameborder="0"></iframe>
+       <iframe height="500" width="620" id="duo_iframe" frameborder="0" align="center"></iframe>
      </div>
 
   </body>


### PR DESCRIPTION
1) Attempted to integrate the compiled jar to a confluence install that was in a non-root context path (i.e. /wiki). Duo didn't play nice. Made duo play nice with others by implementing context path. This was mostly adopted from https://github.com/duosecurity/duo_jira/commit/95199e92da96fc89d04d580e7caa9bd878f3d958 as this was an issue on that side as well already previously fixed.

2) Duo looked sad. Duo shouldn't look sad. Made Duo page follow implemented theme template using the decorator meta.

3) Updated dependency versions as I was having compile issues, but turns out it was related to JAF missing. *shrug*  - Related compile fix is at https://developer.atlassian.com/docs/faq/atlassian-plugin-sdk-faq/maven-cannot-find-java-mail-java-activation-or-jta, so feel free to toss out the update to the library versions.

Random Notes: 
 - Tested on Confluence 5.7
 - Didn't update version number in pom.xml nor include a compiled jar, but can. Not sure your numbering scheme and didnt want to assume 1.3.1.
