### PR TITLE
Adjust test for existing duo install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ if [ ! -e $CONFLUENCE/confluence/WEB-INF/lib ]; then
 fi
 
 # check for existing plugin install
-if [ -e $CONFLUENCE/confluence/WEB-INF/lib/duo.jar -o $CONFLUENCE/confluence/WEB-INF/lib/DuoWeb-*.jar ]; then
+if [ -e $CONFLUENCE/confluence/WEB-INF/lib/duo.jar -o -e $CONFLUENCE/confluence/WEB-INF/lib/DuoWeb-*.jar ]; then
     echo "duo web jar already exists in $CONFLUENCE/confluence/WEB-INF/lib."
     UPGRADE_DUO=1
 fi


### PR DESCRIPTION
The current test for an existing duo install in confluence always finds an install even when nothing is there. The -o flag in the test on line 48 just determines that $CONFLUENCE/confluence/WEB-INF/lib/DuoWeb-*.jar is a string and so the test is always true.