### PR TITLE
Specify MIME types for a few of our fields

### DIFF
--- a/duo_twofactor/src/main/resources/duologin.vm
+++ b/duo_twofactor/src/main/resources/duologin.vm
@@ -10,8 +10,8 @@
     <h1>Duo Authentication</h1>
 
      <div>
-       <script src="$contextPath/download/resources/com.duosecurity.confluence.plugins.duo-twofactor:resources/Duo-Web-v2.js"></script>
-       <script>
+       <script type="text/javascript" src="$contextPath/download/resources/com.duosecurity.confluence.plugins.duo-twofactor:resources/Duo-Web-v2.js"></script>
+       <script type="text/javascript">
          Duo.init({
            'host': "$duoHost",
            'sig_request': "$sigRequest",
@@ -19,7 +19,7 @@
          });
        </script>
        <iframe id="duo_iframe" frameborder="0"></iframe>
-       <style>
+       <style type="text/css">
           #duo_iframe {
             width: 100%;
             min-width: 304px;


### PR DESCRIPTION
As someone pointed out on our Jira repo, Atlassian seems to be aiming to enable strict mime type checking. Hopefully this gets us ahead of that change for confluence as well.